### PR TITLE
add feature to allow syncing ms teams available/away with host machine state

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -41,16 +41,16 @@ function fetchHostIdle() {
         }).then(result => {  // if not 200 OK response, emulate mouse move
             if (result.status != 200) {
                 moveMouse()
-                console.log("moveMouse() not ok")
+                // console.log("moveMouse() not ok")
             }
         }).catch(error => {  // on error, emulate mouse move
             moveMouse()
-            console.log("moveMouse() catch promise")
+            // console.log("moveMouse() catch promise")
         });
     } catch (error) {
         // on error, emulate mouse move
         moveMouse()
-        console.log("moveMouse() catch")
+        // console.log("moveMouse() catch")
     }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -36,7 +36,10 @@ function moveMouse(){
 
 function fetchHostIdle() {
     try {
-        fetch('http://localhost:21080', {
+        const params = new URLSearchParams();
+        params.append("title", document.title);
+
+        fetch(`http://localhost:21080?${params}`, {
             method: 'GET'
         }).then(result => {  // if not 200 OK response, emulate mouse move
             if (result.status != 200) {

--- a/src/main.js
+++ b/src/main.js
@@ -2,10 +2,10 @@
  * This is the interval, measured in seconds, at which to run the script.
  * In other words, this is how often the script should run.
  *
- * The default value is 10, so the mouse will be jiggled every 10 seconds.
+ * The default value is 3 minutes.
  * If you want to change how often the script runs, modify this value.
  */
-const intervalSeconds = 10;
+const intervalSeconds = (3 * 60);
 
 /**
  * Convert from seconds to milliseconds, since javascript intervals
@@ -34,7 +34,27 @@ function moveMouse(){
     document.dispatchEvent(evt);
 }
 
+function fetchHostIdle() {
+    try {
+        fetch('http://localhost:21080', {
+            method: 'GET'
+        }).then(result => {  // if not 200 OK response, emulate mouse move
+            if (result.status != 200) {
+                moveMouse()
+                console.log("moveMouse() not ok")
+            }
+        }).catch(error => {  // on error, emulate mouse move
+            moveMouse()
+            console.log("moveMouse() catch promise")
+        });
+    } catch (error) {
+        // on error, emulate mouse move
+        moveMouse()
+        console.log("moveMouse() catch")
+    }
+}
+
 /**
- * Finally, tell the web page to jiggle the mouse at the defined interval.
+ * Finally, tell the web page to check if the host is idle
  */
-setInterval(moveMouse, intervalMillis);
+setInterval(fetchHostIdle, intervalMillis);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "KeepTeamsAwake",
+  "name": "KeepTeamsAwake-localhostTimeout",
   "version": "1.0.2",
 
   "description": "Prevents the Microsoft Teams website or PWA from sleeping",


### PR DESCRIPTION
added feature to fetch a http response from localhost:21080 which can be used to indicate idle state of host machine.

ms teams in browser can then match idle/locked state of the the host machine and change to 'away' state if the machine has been idle for an amount of time, or if machine has screen locked, or any other condition that the user chooses.

if localhost:21080 returns http response code 200 OK the 'mouse jiggle' in the extension will not occur and, within some minutes, ms teams in the browser will go to 'away' status. return of any other http status code (or error) will result in 'mouse jiggle' being performed (ie same as existing functionality)

example implementation of host machine systemd service to provide idle/not-idle/screen-locked status to the extension;

systemd unit file: **~/.local/share/systemd/user/keep-teams-awake.socket**

```
[Unit]
Description=keep teams awake browser extension socket

[Socket]
Accept=yes
ListenStream=127.0.0.1:21080

[Install]
WantedBy=sockets.target
```


systemd unit file: **~/.local/share/systemd/user/keep-teams-awake@.service**
( replace {username} )

```
[Unit]
Description=keep teams awake browser service
After=network.target keep-teams-awake.socket
Requires=keep-teams-awake.socket

[Service]
Type=simple
StandardInput=socket
StandardOutput=socket
StandardError=journal
ExecStart=/home/{username}/bin/keep-teams-awake {username}
TimeoutStopSec=5

[Install]
```

bash script to check session idle and screen locked status: **/home/username/bin/keep-teams-awake**

```
#!/bin/bash

# this is executed from a systemd socket and service
# it is used by keep-teams-awake browser extension to keep ms teams in 'available' status as long as session is not idle or locked


[[ $1 == "" ]] && { echo "pass a username on the command line" >&2; exit 1; }

# ms teams can switch to 'away' status after 10 minutes
AWAY_AFTER_SECS=$(( 10 * 60 ))

# get rounded time in seconds that session has been idle
SESSION_IDLE_SECS=$(( ($(xssstate -i) + 500) / 1000 ))

# is user's session locked
while read -r SESSION USERID USERNAME SEAT TTY; do
  if [[ $USERNAME == "$1" ]]; then   # if session is for passed username
    # get session's locked hint
    SESSION_LOCKED=$(/usr/bin/loginctl show-session $SESSION --value -p LockedHint)
    break
  fi
done < <(/usr/bin/loginctl list-sessions --no-legend --no-pager)  # get list of sessions

# default status to keep teams as 'available'
HTTP_STATUS="202 Accepted"

# if session is idle or locked, let teams go to 'away' status
if [[ $SESSION_IDLE_SECS -gt $AWAY_AFTER_SECS || $SESSION_LOCKED != "no" ]]; then
  HTTP_STATUS="HTTP/1.1 200 OK"
fi

# http response
echo -e 'HTTP/1.1 '$HTTP_STATUS'\nContent-Length: 0\nAccess-Control-Allow-Headers: *\nAccess-Control-Allow-Origin: *\n'

# log to stderr (journal for systemd service)
echo "idle for $SESSION_IDLE_SECS of $AWAY_AFTER_SECS, $SESSION_LOCKED lock, $HTTP_STATUS" >&2
```



